### PR TITLE
Improve output of context key-value pairs

### DIFF
--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -247,9 +247,9 @@ func main() {
 
 				for i, ve := range sample {
 					if ve.Context != nil {
-						sstrings[i] = fmt.Sprintf("%d:'%v':%v", ve.Line, ve.Value, ve.Context)
+						sstrings[i] = fmt.Sprintf("line %d: `%s`\n%s", ve.Line, ve.Value, ve.Context)
 					} else {
-						sstrings[i] = fmt.Sprintf("%d:'%v'", ve.Line, ve.Value)
+						sstrings[i] = fmt.Sprintf("line %d: `%s`", ve.Line, ve.Value)
 					}
 				}
 

--- a/errors.go
+++ b/errors.go
@@ -131,7 +131,7 @@ func (e ValidationError) Error() string {
 	}
 
 	if e.Context != nil {
-		return fmt.Sprintf("%s: %s: %s", location, e.Err, e.Context)
+		return fmt.Sprintf("%s: %s\n%s", location, e.Err, e.Context)
 	}
 
 	return fmt.Sprintf("%s: %s", location, e.Err)

--- a/validators.go
+++ b/validators.go
@@ -43,12 +43,12 @@ func (c Context) String() string {
 
 	for k, v := range c {
 		if !isZeroValue(v) {
-			toks[i] = fmt.Sprintf("%s:%v", k, v)
+			toks[i] = fmt.Sprintf("%s = %v", k, v)
 			i++
 		}
 	}
 
-	return fmt.Sprintf("(%s)", strings.Join(toks, ", "))
+	return fmt.Sprintf("{%s}", strings.Join(toks, ", "))
 }
 
 type ValidateFunc func(value string, cxt Context) *ValidationError


### PR DESCRIPTION
Each key-value pair is now on a separate line and indented slightly.

Signed-off-by: Byron Ruth <b@devel.io>