### PR TITLE
Add support for ‘continuing on error’

### DIFF
--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -355,7 +355,7 @@ func errLineSteps(errs []*validator.ValidationError) []string {
 			continue
 		}
 
-		if err.Line == start+1 {
+		if err.Line == end+1 {
 			end = err.Line
 			continue
 		}

--- a/csv_test.go
+++ b/csv_test.go
@@ -2,6 +2,9 @@ package validator
 
 import (
 	"bytes"
+	"fmt"
+	"io"
+	"strings"
 	"testing"
 )
 
@@ -18,6 +21,8 @@ var (
 		// Unquoted empty value
 		{2, `"a",`, []string{"a", ""}},
 		{2, `,"a"`, []string{"", "a"}},
+		{2, `,`, []string{"", ""}},
+		{3, `,,`, []string{"", "", ""}},
 
 		// Quotes
 		{1, `"""b"""`, []string{`"b"`}},
@@ -54,57 +59,249 @@ func compareRows(a, b []string) bool {
 	return true
 }
 
-func TestParseCSVLineValid(t *testing.T) {
-	// Shared array.
-	buf := [3]string{}
-	r := bytes.NewBuffer(nil)
+func tableToCSV(t [][]string) []byte {
+	buf := bytes.NewBuffer(nil)
+	sep := []byte{','}
+	nl := []byte{'\n'}
 
-	for i, test := range validLines {
-		r.Reset()
-		r.Write([]byte(test.Line + "\n"))
+	for _, r := range t {
+		for i, c := range r {
+			if i != 0 {
+				buf.Write(sep)
+			}
+			if c != "" {
+				buf.WriteString(fmt.Sprintf(`"%s"`, c))
+			}
+		}
 
-		row := buf[:test.Len]
-		col, err := parseCSVLine(r, row)
+		buf.Write(nl)
+	}
+
+	return buf.Bytes()
+}
+
+func tableToToks(t [][]string) []string {
+	var toks []string
+
+	for _, r := range t {
+		toks = append(toks, r...)
+	}
+
+	return toks
+}
+
+func TestCSVReader(t *testing.T) {
+	table := [][]string{
+		{"name", "gender", "state"},
+		{"Joe", "M", "GA"},
+		{"Sue", "F", "NJ"},
+		{"Bob", "M", "NY"},
+		{"Bill", "M", ""}, // trailing comma
+	}
+
+	buf := bytes.NewBuffer(tableToCSV(table))
+	toks := tableToToks(table)
+
+	cr := DefaultCSVReader(buf)
+
+	var i, c, l int
+
+	for i = 0; cr.Scan(); i++ {
+		// Increment line and reset column every three tokens.
+		if i%3 == 0 {
+			l++
+			c = 1
+		} else {
+			c++
+		}
+
+		if i == len(toks) {
+			t.Errorf("scan exceeded %d tokens", i+1)
+			break
+		}
+
+		tok := cr.Text()
+
+		if tok != toks[i] {
+			t.Errorf("line %d, column %d: expected %s, got %s", cr.LineNumber(), cr.ColumnNumber(), toks[i], tok)
+		}
+
+		if cr.LineNumber() != l {
+			t.Errorf("expected line %d, got %d for %s", l, cr.LineNumber(), tok)
+		}
+
+		if cr.ColumnNumber() != c {
+			t.Errorf("expected column %d, got %d for %s", c, cr.ColumnNumber(), tok)
+		}
+	}
+
+	if err := cr.Err(); err != io.EOF {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if i != len(toks) {
+		t.Errorf("expected %d, got %d", len(toks), i)
+	}
+}
+
+func TestCSVScanLine(t *testing.T) {
+	table := [][]string{
+		{"name", "gender", "state"},
+		{"Joe", "M", "GA"},
+		{"Sue", "F", "NJ"},
+		{"Bob", "M", "NY"},
+		{"Bill", "M", ""},
+	}
+
+	buf := bytes.NewBuffer(tableToCSV(table))
+
+	cr := DefaultCSVReader(buf)
+
+	var (
+		i   int
+		err error
+		row = make([]string, 3)
+	)
+
+	for {
+		err = cr.ScanLine(row)
+
+		if err == io.EOF {
+			break
+		}
 
 		if err != nil {
-			t.Errorf("line %d: unexpected error: %s at column %d", i+1, err, col)
-			continue
+			t.Errorf("%d: unexpected error: %s", i, err)
 		}
 
-		if !compareRows(row, test.Output) {
-			t.Errorf("line %d: expected %v, got %v", i+1, test.Output, row)
+		if cr.LineNumber() != i+1 {
+			t.Errorf("%d: got wrong line number %d", i, cr.LineNumber())
 		}
+
+		if !compareRows(table[i], row) {
+			t.Errorf("%d: wrong row, got %v", row)
+		}
+
+		i++
+	}
+
+	if i != 5 {
+		t.Errorf("scanned wrong number of lines %d", i)
 	}
 }
 
-func TestParseCSVLineInvalid(t *testing.T) {
-	// Shared array.
-	buf := [3]string{}
-	r := bytes.NewBuffer(nil)
+func TestCSVScanLineBadInput(t *testing.T) {
+	rows := []string{
+		`"name","gender",state`,
+		`Joe,"M", "GA"`,
+		`"Sue", "F", "NJ"`,
+		`"Bob",M,NY"`,
+	}
 
-	for i, test := range invalidLines {
-		r.Reset()
-		r.Write([]byte(test.Line + "\n"))
+	buf := bytes.NewBuffer([]byte(strings.Join(rows, "\n")))
+	cr := DefaultCSVReader(buf)
 
-		row := buf[:test.Len]
-		_, err := parseCSVLine(r, row)
+	var (
+		i   int
+		err error
+		row = make([]string, 3)
+	)
+
+	for {
+		err = cr.ScanLine(row)
+
+		if err == io.EOF {
+			break
+		}
+
+		if cr.Line() != rows[i] {
+			t.Errorf("%d: bad line `%s`", i, cr.Line())
+		}
 
 		if err == nil {
-			t.Errorf("line %d: expected error, got %v", i+1, row)
+			t.Errorf("%d: expected error", i)
+		}
+
+		if cr.LineNumber() != i+1 {
+			t.Errorf("%d: got wrong line number %d", i, cr.LineNumber())
+		}
+
+		i++
+	}
+
+	if i != 4 {
+		t.Errorf("scanned wrong number of lines %d", i)
+	}
+}
+
+func TestCSVReaderBadInput(t *testing.T) {
+	rows := []string{
+		`"name","gender",state`,
+		`Joe,"M", "GA"`,
+		`"Sue", "F", "NJ"`,
+		`"Bob",M,NY"`,
+	}
+
+	expectedToks := []struct {
+		Token  string
+		Error  bool
+		Line   int
+		Column int
+	}{
+		{"name", false, 1, 1},
+		{"gender", false, 1, 2},
+		{"state", true, 1, 3},
+		{`Joe,"M", "GA"`, true, 2, 1},
+		{"Sue", false, 3, 1},
+		{` "F", "NJ"`, true, 3, 2},
+		{"Bob", false, 4, 1},
+		{`M,NY"`, true, 4, 2},
+	}
+
+	buf := bytes.NewBuffer([]byte(strings.Join(rows, "\n")))
+	cr := DefaultCSVReader(buf)
+
+	var (
+		err error
+		tok string
+	)
+
+	for i := 0; cr.Scan(); i++ {
+		tok = cr.Text()
+		exp := expectedToks[i]
+
+		if cr.LineNumber() != exp.Line {
+			t.Errorf("%d: expected line %d, got %d", i, exp.Line, cr.LineNumber())
+		}
+
+		if cr.ColumnNumber() != exp.Column {
+			t.Errorf("%d: expected column %d, got %d", i, exp.Column, cr.ColumnNumber())
+		}
+
+		if exp.Token != tok {
+			t.Errorf("%d: expected token `%s`, got `%s`", i, exp.Token, tok)
+		}
+
+		err = cr.Err()
+
+		if err == nil && exp.Error {
+			t.Errorf("%d: expected error", i)
+		} else if err != nil && !exp.Error {
+			t.Errorf("%d: unexpected error: %s", i, err)
 		}
 	}
 }
 
-func BenchmarkParseCSVLine(b *testing.B) {
-	buf := []byte(line)
-	r := bytes.NewBuffer(buf)
-	rec := [25]string{}
+func BenchmarkCSVReaderScan(b *testing.B) {
+	cr := DefaultCSVReader(&bytes.Buffer{})
+
+	data := []byte(line)
 
 	for i := 0; i < b.N; i++ {
-		b.StartTimer()
-		parseCSVLine(r, rec[:0])
+		_, data, _, _ = cr.scanField(data)
 
-		b.StopTimer()
-		r = bytes.NewBuffer(buf)
+		if len(data) == 0 {
+			data = []byte(line)
+		}
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -37,6 +37,16 @@ var ErrBareQuote = &Error{
 	Description: `Value contains bare double quotes (")`,
 }
 
+var ErrUnterminatedColumn = &Error{
+	Code:        204,
+	Description: `Column is not terminated with a quote.`,
+}
+
+var ErrUnquotedColumn = &Error{
+	Code:        205,
+	Description: `Non-empty column must be quoted.`,
+}
+
 var ErrRequiredValue = &Error{
 	Code:        300,
 	Description: "Value is required",

--- a/validator_test.go
+++ b/validator_test.go
@@ -31,8 +31,9 @@ func BenchmarkValidateRow(b *testing.B) {
 
 	buf := []byte(line)
 	r = bytes.NewBuffer(buf)
-	row := make([]string, 25)
-	parseCSVLine(r, row)
+
+	cr := DefaultCSVReader(r)
+	row, _ := cr.Read()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
The CSVReader now continues parsing on error by scanning to the end
of the line and then resuming field-level parsing.

Signed-off-by: Byron Ruth <b@devel.io>